### PR TITLE
Add --auto switch to start in /auto mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file. This change
 ### [Unreleased]
 
 Added
-- *TBD*
+- Added --auto command line argument to start in /auto mode
+- Now fully respect --port argument (and log to port specific log files)
 
 ### [0.8.5] - 2016-06-03
 

--- a/src/planviz/actions.cljs
+++ b/src/planviz/actions.cljs
@@ -1088,7 +1088,10 @@
                  (rmethod {} :login)
                  (tasks/deferred))
         finish (-> dlogin
-                 (chain #(if (:error %) false (:login/remote %)))
+                 (chain #(if (:error %) false
+                             (do
+                               (if (get-in % [:login/settings :auto]) (auto))
+                               (:login/remote %))))
                  (chain #(do (status-msg "logged in as" %)
                              (st/app-set :app/client %)
                              true))

--- a/src/planviz/cli.clj
+++ b/src/planviz/cli.clj
@@ -13,6 +13,7 @@
             [environ.core :refer [env]]
             [clojure.java.shell :refer [sh]]
             [me.raynes.fs :as fs]
+            [avenir.utils :as au :refer [as-boolean]]
             [planviz.server :as server])
   (:gen-class))
 
@@ -36,7 +37,7 @@
   "Save command line arguments to config/planviz.edn"
   {:added "0.8.0"}
   [options]
-  (let [{:keys [help version verbose exchange input
+  (let [{:keys [help version verbose auto exchange input
                 rmq-host rmq-port host port
                 cwd arguments]} options
         cmd (or (first arguments) default-action)
@@ -63,6 +64,7 @@
    ["-v" "--verbose" "Increase verbosity"
     :default 0
     :assoc-fn (fn [m k _] (update-in m [k] inc))]
+   ["-a" "--auto" "Start in /auto mode"]
    ["-e" "--exchange EXCHANGE" "RMQ Exchange Name"
     :default "tpn-updates"]
    ["-i" "--input INPUT" "Input file(s) {TPN|HTN|HTN=TPN}"
@@ -135,9 +137,10 @@
   (let [cwd (or (:planviz-cwd env) (:user-dir env))
         {:keys [options arguments errors summary]}
         (config-parse-opts cwd args cli-options)
-        {:keys [help version verbose exchange input
+        {:keys [help version verbose auto exchange input
                 rmq-host rmq-port host port url-config]} options
-        options (assoc options :cwd cwd :arguments arguments)
+        auto (as-boolean auto)
+        options (assoc options :auto auto :cwd cwd :arguments arguments)
         cmd (or (last arguments) default-action)
         action (get actions cmd)
         verbose? (pos? (or verbose 0))
@@ -162,6 +165,7 @@
       (println "verbosity level:" verbose)
       (println "rmq-host:" rmq-host)
       (println "rmq-port:" rmq-port)
+      (println "auto:" auto)
       (println "exchange:" exchange)
       (println "host:" host)
       (println "port:" port)

--- a/src/planviz/client.cljs
+++ b/src/planviz/client.cljs
@@ -47,7 +47,7 @@
 
 (defn initialize [bounce]
   (tasks/on-started
-    #(ws/setup (make-url :protocol "ws" :port 8080 :uri "/ws")
+    #(ws/setup (make-url :protocol "ws" :uri "/ws")
        {:message read-default
         :open login}))
   (if bounce

--- a/src/planviz/server.clj
+++ b/src/planviz/server.clj
@@ -7,6 +7,7 @@
 (ns planviz.server
   (:gen-class) ;; for :uberjar
   (:require [clojure.java.io :as io]
+            [clojure.java.shell :refer [sh]]
             [clojure.pprint :as pp :refer [pprint]]
             [clojure.tools.cli :as cli]
             [clojure.string :as string]
@@ -60,10 +61,22 @@
 
 ;; ---------------------------------------
 
+(defn hostname []
+  (try
+    (let [{:keys [exit out err]} (sh "hostname")]
+      (if (zero? exit)
+        (string/replace out #"\s" "")
+        "localhost"))
+    (catch Exception e
+      (println "unable to run the hostname command:"
+        (.. e getCause getMessage))
+      "localhost"
+      )))
+
 (def rmq-default-host "localhost")
 (def rmq-default-port 5672)
 (def rmq-default-exchange "tpn-updates")
-(def planviz-default-host "localhost")
+(def planviz-default-host (hostname))
 (def planviz-default-port 8080)
 (def pamela-visualization-key "pamela.viz")
 
@@ -120,13 +133,17 @@
                       }
 
    :output-fn log/default-output-fn ; (fn [data]) -> string
-   :appenders
-   {:spit (log/spit-appender {:fname "./logs/planviz.log"})}})
+   ;; :appenders
+   ;; {:spit (log/spit-appender {:fname "./logs/planviz.log"})}
+   })
 
-(defn log-initialize []
-  (log/set-config! log-config)
-  (log/info "planviz logging initialized\n---------------------------------\n")
-  (swap! state assoc :logging true))
+(defn log-initialize [port]
+  (let [logfile (str "./logs/planviz-" port ".log")
+        appenders {:spit (log/spit-appender {:fname logfile})}
+        config (assoc log-config :appenders appenders)]
+    (log/set-config! config)
+    (log/info "planviz logging initialized\n---------------------------------\n")
+    (swap! state assoc :logging true)))
 
 (def non-websocket-request
   {:status 400
@@ -845,13 +862,13 @@
       (unknown-update routing-key json-str))))
 
 ;; This is the message processing loop
-(defn start-msgs []
+(defn start-msgs [port]
   (if (get-msgs)
     (log/debug "msgs already running!")
     (let [msgs (chan 10)]
       (swap! state assoc :msgs msgs)
       (if-not (:logging @state)
-        (log-initialize))
+        (log-initialize port))
       (log/info "msgs started")
       (go-loop [msg (<! msgs)]
         (if-not msg
@@ -1009,15 +1026,15 @@
 ;; {TPN|HTN|HTN=TPN}
 (defn startup [host port input cwd]
   (if-not (get-msgs)
-    (start-msgs)) ;; lazily does log-initialize
+    (start-msgs port)) ;; lazily does log-initialize
   (if (get-in @state [:rmq :connection])
     (shutdown))
   (let [{:keys [rmq-host rmq-port exchange]} (:rmq @state)
         connection (connect-to-rmq rmq-host rmq-port)]
     (if-not connection
       (do
-        (println "PLANVIZ cannot connect to RabbitMQ at" host ":" port)
-        (log/error "PLANVIZ cannot connect to RabbitMQ at" host ":" port))
+        (println "PLANVIZ cannot connect to RabbitMQ at" rmq-host ":" rmq-port)
+        (log/error "PLANVIZ cannot connect to RabbitMQ at" rmq-host ":" rmq-port))
       (let [channel (lch/open connection)
             _ (le/declare channel exchange "topic")
             queue (lq/declare channel)

--- a/src/planviz/server.clj
+++ b/src/planviz/server.clj
@@ -191,7 +191,8 @@
 
 (defn login []
   (if *remote*
-    (let [login {:login/remote *remote*}]
+    (let [login {:login/remote *remote*
+                 :login/settings (:settings @state)}]
       (log/info "LOGIN" *remote*)
       login)
     false))
@@ -830,7 +831,7 @@
         {:keys [exchange routing-key app-id]} metadata
         details (str "MSG from exchange: " exchange " routing-key: " routing-key
                   " app-id: " app-id
-                  ;; \newline (with-out-str (clojure.pprint/pprint json-str))
+                  \newline (with-out-str (clojure.pprint/pprint json-str))
                   )]
     (log/info details)
     (condp = routing-key ;; case does not work with a symbol below
@@ -1043,8 +1044,8 @@
             (log/info "PLANVIZ server ready")
             (when (and (not (repl?)) (get-in @state [:rmq :connection]))
               (while true
-                (print ".")
-                (flush)
+                ;; (print ".")
+                ;; (flush)
                 (sleep 10)))))))))
 
 (defn- compare-url-config [a b]
@@ -1094,14 +1095,16 @@
   "Visualize HTN and TPN plans"
   {:added "0.8.0"}
   [options]
-  (let [{:keys [cwd verbose exchange rmq-host rmq-port
+  (let [{:keys [cwd verbose auto exchange rmq-host rmq-port
                 host port input url-config]} options
+        settings {:auto auto}
         exchange (or exchange rmq-default-exchange)
         rmq-host (or rmq-host rmq-default-host)
         rmq-port (or rmq-port rmq-default-port)
         host (or host planviz-default-host)
         port (or port planviz-default-port)]
     (setup-url-config cwd url-config)
+    (swap! state assoc :settings settings)
     (swap! state update-in [:rmq]
       assoc :rmq-host rmq-host :rmq-port rmq-port :exchange exchange)
     (startup host port input cwd))) ;; lazily does start-msgs


### PR DESCRIPTION
Fixes #10 Set /auto mode via command line switch
Turn on verbose RMQ message dump in log
Turn off printing dots while running

Signed-off-by: Tom Marble tmarble@info9.net
