### PR TITLE
Fixed startup bug

### DIFF
--- a/src/planviz/cli.clj
+++ b/src/planviz/cli.clj
@@ -7,6 +7,7 @@
 (ns planviz.cli
   "Temporal Planning Network schema command line interface"
   (:require [clojure.string :as string]
+            [clojure.repl :refer [pst]]
             [clojure.java.io :refer :all] ;; for as-file
             [clojure.tools.cli :refer [parse-opts]]
             [clojure.pprint :as pp :refer [pprint]]
@@ -178,16 +179,14 @@
         (exit 1 (str "Unknown action: \"" cmd "\". Must be one of: "
                   (keys actions)))
         (usage summary))
-      (do ;; try
-        (println "BEFORE ACTION")
+      (try
         (action options)
-        (println "AFTER ACTION")
-        ;; (catch Throwable e ;; note AssertionError not derived from Exception
-        ;;   ;; FIXME: use proper logging
-        ;;   (binding [*out* *err*]
-        ;;     (println "ERROR caught exception:" (.getMessage e)))
-        ;;   (exit 1))
-        ))
+        (catch Throwable e
+          (let [msg (with-out-str (pst e))]
+            (binding [*out* *err*]
+              (server/log-if-possible msg)
+              (println msg)
+              (exit 1))))))
     (exit 0)))
 
 (defn -main

--- a/src/planviz/net.clj
+++ b/src/planviz/net.clj
@@ -1,0 +1,34 @@
+;; Copyright © 2016 Dynamic Object Language Labs Inc.
+;;
+;; This software is licensed under the terms of the
+;; Apache License, Version 2.0 which can be found in
+;; the file LICENSE at the root of this distribution.
+
+(ns planviz.net
+  (:require [clojure.string :as string])
+  (:import [java.net
+            DatagramSocket ServerSocket SocketException]
+           [java.io
+            IOException]))
+
+(defn port-available?
+  "Returns true if the port is available to be bound (for both UDP and TCP)"
+  [port]
+  (let [state (atom {:available? false :ss nil :ds nil})]
+    (if (and (number? port) (> port 0) (<= port 65535))
+      (try
+        (swap! state assoc :ss (ServerSocket. port))
+        (.setReuseAddress (:ss @state) true)
+        (swap! state assoc :ds (DatagramSocket. port))
+        (.setReuseAddress (:ds @state) true)
+        (swap! state assoc :available? true)
+        (catch IOException e
+          false)
+        (catch SocketException e
+          false)
+        (finally
+          (if-let [ds (:ds @state)]
+            (.close ds))
+          (if-let [ss (:ss @state)]
+            (.close ss)))))
+    (:available? @state)))


### PR DESCRIPTION
PLANVIZ now verifies the port is available before starting up.
In addition stacktraces are now caught and printed if exceptions
are thrown during execution.

Signed-off-by: Tom Marble tmarble@info9.net
