### PR TITLE
PLANVIZ style fixes

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -158,7 +158,7 @@
 (deftask cider-boot
   "Cider boot params task"
   []
-  (if false ;; CIDER works on the client (true) or server (false)
+  (if true ;; CIDER works on the client (true) or server (false)
     (cljs-dev)
     (comp
       (server-resources)

--- a/src/planviz/tplan.cljs
+++ b/src/planviz/tplan.cljs
@@ -45,7 +45,7 @@
                        :ysize 10
                        :nodesep 40
                        :ranksep 50 ;; (* ??? (+ ysize nodesep))
-                       :label-char 5
+                       :label-char 7
                        :min-length 1
                        :plid nil
                        :network-plid-id nil
@@ -55,7 +55,7 @@
                        :ysize 20; 50
                        :nodesep 80 ;; 250
                        :ranksep 100 ;; 250 ;; (* ??? (+ ysize nodesep))
-                       :label-char 5
+                       :label-char 7
                        :min-length 1
                        :plid nil
                        :network-plid-id nil

--- a/src/planviz/ui.cljs
+++ b/src/planviz/ui.cljs
@@ -77,7 +77,7 @@
   (let [n (if (keyword? s) (name s) s)]
     (string/replace n "." "-")))
 
-(def xchar 4)
+(def xchar 5)
 (def ychar 10)
 (def ydesc 3) ;; descender
 
@@ -306,13 +306,16 @@
               marker-end (if cnstr?
                            (if hidden
                              nil
-                             (str "url(#arrow" length-class ")"))
+                             (str "url(#arrow" length-class
+                               ;; "-" (name state)
+                               ")"))
                            (if virtual? "url(#arrowlight)"
                                (if (keyword-identical? network-type :hem-network)
                                  "url(#arrowhem)"
                                  (if hidden
                                    nil ;; "url(#arrowlight)"
-                                   "url(#arrowhead)"))))
+                                   ;; "url(#arrowhead)"
+                                   (str "url(#arrowhead-" (name state) ")")))))
               marker-start nil ;; (if (keyword-identical? type :choice-edge) "url(#choicehem)")
               class (str (safe-type-name type) "-"
                       (if hidden "hidden" (name state)) length-class)
@@ -441,6 +444,15 @@
 (def markers
   (str
     "<marker id=\"arrowhead\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-normal\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-impossible\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-start\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-negotiation\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-best\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-active\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-started\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-finished\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
+    "<marker id=\"arrowhead-failed\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"17\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
     "<marker id=\"choicehem\" orient=\"auto\" markerHeight=\"5\" markerWidth=\"5\" refY=\"0\" refX=\"-70\" viewBox=\"-5 -5 10 10\"><circle r=\"5\"></circle></marker>\n"
     "<marker id=\"arrowhem\" orient=\"auto\" markerHeight=\"5\" markerWidth=\"5\" refY=\"0\" refX=\"5\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"
     "<marker id=\"arrowlight\" orient=\"auto\" markerHeight=\"4\" markerWidth=\"4\" refY=\"0\" refX=\"19\" viewBox=\"0 -5 10 10\"><path d=\"M0,-5L10,0L0,5\"></path></marker>\n"


### PR DESCRIPTION
Fixed illegal CSS Syntax (use of """ for comments is incorrect)

Fixed font metrics for more likely available font choices
    font-family: Helvetica, Verdana, Arial, sans-serif;

Changed HTN "choice-edge-normal" style to the be the same
as "parallel-edge-normal".

Added arrowhead styles to match edge states.

Verified HTN node state should take into account intermediate
dispatched states between :normal and :finished.

Signed-off-by: Tom Marble tmarble@info9.net
