### PR TITLE
Updated to 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file. This change
 Added
 - *TBD*
 
+### [0.8.7] - 2016-09-30
+
+Changed
+- Updated dependencies
+- Repositioned label and sequence-label notations
+- Activities are shown with :name (if that slot was set)
+  else derived based on ui/construct-label
+- Now support a more elaborate edge tool tip which includes
+  plant, plantid, interface, argsmap, cost, reward, controllable
+
 ### [0.8.6] - 2016-06-03
 
 Added

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 ;; the file LICENSE at the root of this distribution.
 
 (def project 'dollabs/planviz)
-(def version "0.8.6")
+(def version "0.8.7")
 (def description "Planning Network Visualization")
 (def project-url "https://github.com/dollabs/planviz")
 (def main 'planviz.cli)
@@ -14,21 +14,21 @@
   :source-paths #{"src" "html"}
   :resource-paths #{"src" "html"}
   :dependencies   '[[org.clojure/clojure "1.8.0"]
-                    [org.clojure/clojurescript "1.9.93"]
+                    [org.clojure/clojurescript "1.9.229"]
                     ;; both
                     [avenir "0.2.1"]
                     [dollabs/webtasks "0.2.1"]
                     [dollabs/webkeys "0.2.0"]
-                    [org.clojure/core.async "0.2.385"]
+                    [org.clojure/core.async "0.2.391"]
                     ;; server
                     [org.clojure/tools.cli "0.3.5"]
                     [me.raynes/fs "1.4.6"]
-                    [com.cognitect/transit-clj "0.8.285"]
-                    [environ "1.0.3"]
+                    [com.cognitect/transit-clj "0.8.288"]
+                    [environ "1.1.0"]
                     [clj-time "0.12.0"]
                     [com.taoensso/timbre "4.7.3"]
                     [com.novemberain/langohr "3.6.1"]
-                    [dollabs/plan-schema "0.2.7"]
+                    [dollabs/plan-schema "0.2.9"]
                     ;; web server
                     [org.clojure/data.json "0.2.6"]
                     [ring/ring-core "1.5.0"]
@@ -37,13 +37,13 @@
                     [amalloy/ring-gzip-middleware "0.1.3"]
                     [compojure "1.5.0"]
                     [enlive "1.1.6"]
-                    [aleph "0.4.2-alpha6"]
+                    [aleph "0.4.2-alpha8"]
                     ;; client
                     [com.cognitect/transit-cljs "0.8.239"]
-                    [cljsjs/react-dom-server "15.2.1-1"]  ;; for sablono
-                    [cljsjs/react-dom "15.2.1-1"] ;; for sablono
-                    [org.omcljs/om "1.0.0-alpha40"]
-                    [sablono "0.7.3"]
+                    [cljsjs/react-dom-server "15.3.1-0"]  ;; for sablono
+                    [cljsjs/react-dom "15.3.1-0"] ;; for sablono
+                    [org.omcljs/om "1.0.0-alpha46"]
+                    [sablono "0.7.4"]
                     ;; cljs-dev
                     [com.cemerick/piggieback "0.2.1"     :scope "test"]
                     [weasel                 "0.7.0"      :scope "test"]

--- a/html/public/css/tplan.css
+++ b/html/public/css/tplan.css
@@ -92,6 +92,8 @@ svg, g, rect, circle, text, symbol, use {
 }
 
 .target-unselected {
+    /* DEBUG */
+    /* fill: lightgrey; */
     fill: none;
 }
 
@@ -292,8 +294,11 @@ svg, g, rect, circle, text, symbol, use {
 /*.............Nodes(TPN)................*/
 
 .parallel-normal, .choice-normal, .unchoice-normal, .state-normal {
-    fill: #66ccff; /* normal; */
-    stroke: #66ccff;  /* #777777*/;
+    fill: #66ccff;
+    stroke: #66ccff;
+    /* DEBUG */
+    /* fill: none; */
+    /* stroke: none; */
     stroke-width: 3px;
 }
 

--- a/src/planviz/server.clj
+++ b/src/planviz/server.clj
@@ -1008,6 +1008,7 @@
           true)))
     (pschema/tpn-filename? filename)
     (let [plan (pschema/tpn-plan {:input [filename] :cwd cwd})]
+      ;; (log/error "RV plan" plan)
       (if (and (map? plan) (:error plan))
         (let [msg (str "error parsing TPN plan: " filename)]
           (log/error msg)

--- a/src/planviz/tplan.cljs
+++ b/src/planviz/tplan.cljs
@@ -502,9 +502,9 @@
                                       edge/probability edge/guard]} edge
                               label (ui/construct-label name label sequence-label
                                       plant plantid command args type value)
-                              extra (ui/construct-extra
-                                      cost reward probability guard)
-                              max-label (max (count label) (count extra))]
+                              ;; CONSIDER ui/construct-edge-tip length
+                              ;; max-label (max (count label) (count tip))
+                              max-label (count label)]
                           ;; unhide non-aggregation edges
                           (if (and (keyword-identical? plan-type :tpn-network)
                                 hidden (not (keyword-identical? type :aggregation)))


### PR DESCRIPTION
Updated dependencies
Repositioned label and sequence-label notations
Activities are shown with :name (if that slot was set)
  else derived based on ui/construct-label
Now support a more elaborate edge tool tip which includes
  plant, plantid, interface, argsmap, cost, reward, controllable

Signed-off-by: Tom Marble tmarble@info9.net
