### PR TITLE
Updates for 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. This change
 
 ### [Unreleased]
 
+Changed
+- _TBD_
+
+### [0.9.0] - 2016-11-16
+
 Added
 - No longer change all user's view to the latest selection (Closes #28)
 - Resolve #30 (cleanup relaxed tpn values, via plan-schema)
@@ -11,7 +16,16 @@ Added
   spinner or giving a status message when loading files.
 - Resolve Selection bug #35. Also disable ring-default not-modified
   headers at log level :trace and :debug (to force *.cljs reloading)
-- *TBD*
+- Update dependencies
+- Added settings dialog menu. Closes:
+  * Leverages various webfonts to allow run time customization
+  * BB 37 TPNVIZ: create a Settings page
+  * BB 48 TPNVIZ: Save settings (server side)
+  * #32 Config Option to change HTN node Font and Size
+- Performance:
+  * use keyword-identical? in favor of = for keyword comparisons
+  * use simple keywords as key-fn's where applicable
+- NOTE: This version requires [dollabs/webkeys "0.4.0"]
 
 ### [0.8.9] - 2016-10-26
 
@@ -133,4 +147,5 @@ Added
 [0.8.4]: https://github.com/dollabs/planviz/compare/0.8.3...0.8.4
 [0.8.8]: https://github.com/dollabs/planviz/compare/0.8.4...0.8.8
 [0.8.9]: https://github.com/dollabs/planviz/compare/0.8.8...0.8.9
-[Unreleased]: https://github.com/dollabs/planviz/compare/0.8.9...HEAD
+[0.9.0]: https://github.com/dollabs/planviz/compare/0.8.0...0.9.0
+[Unreleased]: https://github.com/dollabs/planviz/compare/0.9.0...HEAD

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 ;; the file LICENSE at the root of this distribution.
 
 (def project 'dollabs/planviz)
-(def version "0.8.9")
+(def version "0.9.0")
 (def description "Planning Network Visualization")
 (def project-url "https://github.com/dollabs/planviz")
 (def main 'planviz.cli)
@@ -18,14 +18,14 @@
                     ;; both
                     [avenir "0.2.1"]
                     [dollabs/webtasks "0.2.1"]
-                    [dollabs/webkeys "0.2.0"]
+                    [dollabs/webkeys "0.4.0"]
                     [org.clojure/core.async "0.2.395"]
                     ;; server
                     [org.clojure/tools.cli "0.3.5"]
                     [me.raynes/fs "1.4.6"]
-                    [com.cognitect/transit-clj "0.8.290"]
+                    [com.cognitect/transit-clj "0.8.293"]
                     [environ "1.1.0"]
-                    [clj-time "0.12.0"]
+                    [clj-time "0.12.2"]
                     [com.taoensso/timbre "4.7.4"]
                     [org.slf4j/slf4j-api "1.7.21"]
                     [com.fzakaria/slf4j-timbre "0.3.2"]
@@ -43,16 +43,16 @@
                     [aleph "0.4.2-alpha8"]
                     ;; client
                     [com.cognitect/transit-cljs "0.8.239"]
-                    [cljsjs/react-dom-server "15.3.1-0"]  ;; for sablono
-                    [cljsjs/react-dom "15.3.1-0"] ;; for sablono
+                    [cljsjs/react-dom-server "15.3.1-1"]  ;; for sablono
+                    [cljsjs/react-dom "15.3.1-1"] ;; for sablono
                     [org.omcljs/om "1.0.0-alpha40"]
-                    [sablono "0.7.5"]
+                    [sablono "0.7.6"]
                     ;; cljs-dev
                     [com.cemerick/piggieback "0.2.1"     :scope "test"]
                     [weasel                 "0.7.0"      :scope "test"]
                     [org.clojure/tools.nrepl "0.2.12"    :scope "test"]
                     [adzerk/boot-reload     "0.4.13"     :scope "test"]
-                    [pandeiro/boot-http "0.7.3" :scope "test"]
+                    [pandeiro/boot-http "0.7.6" :scope "test"]
                     [adzerk/boot-cljs       "1.7.228-2"  :scope "test"]
                     [adzerk/boot-cljs-repl  "0.3.3"      :scope "test"]
                     ;; testing/development

--- a/config/monday.settings.edn
+++ b/config/monday.settings.edn
@@ -1,0 +1,8 @@
+{:settings/rewrap-htn-labels false,
+ :settings/font-weight "font-weight-bold",
+ :settings/tooltips true,
+ :settings/font-size "font-size-9",
+ :settings/ychar 10,
+ :settings/auto false,
+ :settings/font-family "font-family-open-sans-condensed",
+ :settings/xchar 5}

--- a/config/test-tuesday-auto.edn
+++ b/config/test-tuesday-auto.edn
@@ -1,0 +1,16 @@
+{:verbose 2,
+ :log-level :trace
+ :exchange "tpn-updates",
+ :input
+ [
+  "../plan-schema/examples/seattle-2016/v1.htn.edn=../plan-schema/examples/seattle-2016/v1.tpn.edn"
+  "../plan-schema/examples/seattle-2016/v2.htn.edn=../plan-schema/examples/seattle-2016/v2.tpn.edn"
+  ],
+ :rmq-host "localhost",
+ :rmq-port 5672,
+ :host "localhost",
+ :port 8080,
+ :url-config ["config/planviz.urls.edn"]
+ :settings "tuesday"
+ :auto true
+ :arguments ["visualize"]}

--- a/config/tuesday.settings.edn
+++ b/config/tuesday.settings.edn
@@ -1,0 +1,8 @@
+{:settings/rewrap-htn-labels true,
+ :settings/font-weight "font-weight-bold",
+ :settings/tooltips true,
+ :settings/font-size "font-size-8",
+ :settings/ychar 9,
+ :settings/auto false,
+ :settings/font-family "font-family-roboto",
+ :settings/xchar 5}

--- a/config/wednesday.settings.edn
+++ b/config/wednesday.settings.edn
@@ -1,0 +1,8 @@
+{:settings/rewrap-htn-labels true,
+ :settings/font-weight "font-weight-light",
+ :settings/tooltips true,
+ :settings/font-size "font-size-9",
+ :settings/ychar 10,
+ :settings/auto false,
+ :settings/font-family "font-family-helvetica",
+ :settings/xchar 5}

--- a/html/public/css/planviz.css
+++ b/html/public/css/planviz.css
@@ -82,21 +82,21 @@ ul.circle {
     z-index: -20;
 }
 
-.help-shown {
+.help-shown, .settings-shown {
     top: 1em;
 }
 
-.help-hidden {
+.help-hidden, .settings-hidden {
     top: -100em;
 }
 
-#help-menu {
+#help-menu, #settings-menu {
     font-size: 0.6em;
     position: absolute;
     padding: 0.5em;
     left: 1em;
     width: calc(100% - 8em);
-    height: calc(100% - 5em);
+    height: calc(100% - 7.5em);
     /* border: solid 3px SlateGrey; */
     border-width: 3px;
     border-style: ridge;
@@ -105,12 +105,12 @@ ul.circle {
     z-index: 30;
 }
 
-#help-menu li {
+#help-menu li, #settings-menu li {
     list-style-type: none;
     /* padding-left: 1em; */
 }
 
-#help-menu-close {
+#help-menu-close, #settings-menu-close {
     position: fixed;
     padding: 0em;
     left: calc(100% - 7em + 3px);
@@ -154,7 +154,7 @@ ul.circle {
     z-index: 5;
 }
 
-.input-box {
+#ib-cmd {
     position: absolute;
     bottom: 0px;
     left: 0px;
@@ -178,7 +178,7 @@ input::-webkit-input-placeholder {
     color: rgba(0,0,0,0.2);
 }
 
-#cmd {
+#cmd, #xchar, #ychar, #filename {
     padding: 2px;
     margin: 0px;
     border-radius: 4px;
@@ -298,6 +298,26 @@ rect.plans {
     -webkit-transform: translateZ(0);
     -ms-transform: translateZ(0);
     transform: translateZ(0);
+}
+
+#examplenode {
+    position: absolute;
+    top: 20px;
+    left: 450px;
+    text-align: center;
+    border-radius: 3px;
+    width: 80px;
+    height: 40px;
+    color: DarkSlateGrey;
+    background: #b3e6ff;
+    text-overflow: clip;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+#filenames {
+    width: 20em;
+    margin: 0.5em;
 }
 
 @-webkit-keyframes load5 {

--- a/html/public/css/tplan.css
+++ b/html/public/css/tplan.css
@@ -5,6 +5,34 @@
    the file LICENSE at the root of this distribution.
 */
 
+@import url('https://fonts.googleapis.com/css?family=PT+Sans+Narrow');
+@import url('https://fonts.googleapis.com/css?family=Roboto');
+/* at 300 you get light and regular, at 400 FAIL */
+@import url('https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300');
+/* at 300 you get light and regular, at 400 you get regular and bold */
+@import url('https://fonts.googleapis.com/css?family=Nunito:400');
+
+.font-family-helvetica {
+    font-family: Helvetica, Verdana, Arial, sans-serif;
+}
+
+.font-family-pt-sans-narrow { font-family: 'PT Sans Narrow'; }
+.font-family-roboto { font-family: 'Roboto'; }
+.font-family-open-sans-condensed { font-family: 'Open Sans Condensed'; }
+.font-family-nunito { font-family: 'Nunito'; }
+
+.font-weight-light { font-weight: 300; }
+.font-weight-regular { font-weight: 400; }
+.font-weight-bold { font-weight: 700; }
+
+.font-size-7 { font-size: 7px; }
+.font-size-8 { font-size: 8px; }
+.font-size-9 { font-size: 9px; }
+.font-size-10 { font-size: 10px; }
+.font-size-11 { font-size: 11px; }
+.font-size-12 { font-size: 12px; }
+.font-size-13 { font-size: 13px; }
+
 svg, g, rect, circle, text, symbol, use {
     pointer-events: all;
 }
@@ -522,7 +550,7 @@ text {
 }
 
 text.node-label {
-    font-size: 7px;
+    /* font-size: 7px; */
     fill: DarkSlateGrey;
 }
 

--- a/src/planviz/cli.clj
+++ b/src/planviz/cli.clj
@@ -81,6 +81,7 @@
     :default server/planviz-default-port
     :parse-fn #(Long/parseLong %)]
    ["-s" "--strict" "Enforce strict plan schema checking"]
+   ["-S" "--settings SETTINGS" "Settings filename config/SETTINGS.settings.edn"]
    ["-u" "--url-config URLCONFIG" "URL Configuration file(s)"
     :default []
     :assoc-fn (fn [m k v] (assoc m k (conj (get m k []) v)))]])
@@ -144,7 +145,8 @@
         {:keys [options arguments errors summary]}
         (config-parse-opts cwd args cli-options)
         {:keys [help version verbose auto exchange input
-                log-level rmq-host rmq-port host port strict url-config]} options
+                log-level rmq-host rmq-port host port strict
+                settings url-config]} options
         log-level (keyword (or log-level "warn"))
         _ (server/log-initialize port log-level (apply pr-str args))
         auto (as-boolean auto)

--- a/src/planviz/components.cljs
+++ b/src/planviz/components.cljs
@@ -46,8 +46,7 @@
   static om/IQuery
   (query [_]
     '[:message-box/id
-      :message-box/value
-      ])
+      :message-box/value])
   Object
   (render [this]
     (let [props (om/props this)]
@@ -65,9 +64,9 @@
   static om/IQuery
   (query [_]
     '[:input-box/id
+      ;; :input-box/numeric?
       :input-box/value
-      :input-box/start
-      :input-box/end
+      :input-box/placeholder-orig
       :input-box/placeholder
       :input-box/size])
   Object
@@ -119,11 +118,8 @@
       :ui/tooltips? ;; show tooltips
       :ui/graph-click ;; fn when a graph item is clicked
       :ui/menu ;; popup menu
-      ])
-  Object
-  (render [this]
-    (let [props (om/props this)]
-      )))
+      :ui/settings ;; settings configuration
+      ]))
 
 (def ui-opts-query (om/get-query UIOpts))
 
@@ -150,11 +146,7 @@
   static om/IQuery
   (query [_]
     '{:node/node-by-plid-id ?node
-      :edge/edge-by-plid-id ?edge})
-  Object
-  (render [this]
-    (let [props (om/props this)]
-      )))
+      :edge/edge-by-plid-id ?edge}))
 
 (def gsi-query (om/get-query GraphSelectionItem))
 (def gsi-refs {})
@@ -167,7 +159,8 @@
     [:node/node-by-plid-id (node-key-fn props)])
   static om/IQueryParams
   (params [_]
-    {:ui-opts [:ui/network-type :ui/node-ids? :ui/tooltips? :ui/graph-click]
+    {:ui-opts [:ui/network-type :ui/node-ids? :ui/tooltips?
+               :ui/graph-click :ui/settings]
      :selection gsi-query})
   static om/IQuery
   (query [_]
@@ -219,8 +212,7 @@
       ;; for display
       :node/selected?
       :node/aggregated?
-      :node/number
-      ])
+      :node/number])
   Object
   (render [this]
     (let [props (om/props this)]
@@ -240,8 +232,8 @@
   static om/IQueryParams
   (params [_]
     {:node [:plan/plid :node/id :node/x :node/y]
-     :ui-opts [:ui/network-type :ui/tooltips? :ui/graph-click]
-     })
+     :ui-opts [:ui/network-type :ui/tooltips? :ui/graph-click
+               :ui/settings]})
   static om/IQuery
   (query [_] ;; NORMAL QUOTE below
     '[{:plans/ui-opts ?ui-opts}
@@ -304,7 +296,7 @@
   static om/IQueryParams
   (params [_]
     {:node [:node/x :node/y]
-     :ui-opts [:ui/show-virtual? :ui/edge-ids?]})
+     :ui-opts [:ui/show-virtual? :ui/edge-ids? :ui/settings]})
   static om/IQuery
   (query [_] ;; NORMAL QUOTE below
     '[{:plans/ui-opts ?ui-opts}
@@ -431,7 +423,7 @@
   static om/IQueryParams
   (params [_]
     {:pan-zoom pan-zoom-query
-     :ui-opts [:ui/show-plan :ui/graph-click :ui/menu]
+     :ui-opts [:ui/show-plan :ui/graph-click :ui/menu :ui/settings]
      :plans plan-query})
   static om/IQuery
   (query [_]
@@ -471,9 +463,14 @@
       :app/css ;; source for css
       :app/url-config ;; url configuration for right click menus
       :app/help ;; help configuration
+      :app/settings ;; for the settings-menu
       {:app/message-box ?message-box}
-      {:app/input-box ?input-box}
-      {:app/pan-zoom ?pan-zoom}])
+      {:app/cmd-box ?input-box}
+      {:app/pan-zoom ?pan-zoom}
+      {:app/xchar-box ?input-box}
+      {:app/ychar-box ?input-box}
+      {:app/filename-box ?input-box}
+      ])
   Object
   (render [this]
     (let [props (om/props this)]
@@ -482,5 +479,8 @@
 
 (def app-query (om/get-query Application))
 (def app-refs {:app/message-box :message-box/message-box-by-id
-               :app/input-box :input-box/input-box-by-id
-               :app/pan-zoom :pan-zoom/pan-zoom-by-id})
+               :app/cmd-box :input-box/input-box-by-id
+               :app/pan-zoom :pan-zoom/pan-zoom-by-id
+               :app/xchar-box :input-box/input-box-by-id
+               :app/ychar-box :input-box/input-box-by-id
+               :app/filename-box :input-box/input-box-by-id})


### PR DESCRIPTION
- Added settings dialog menu.
  * Leverages various webfonts to allow run time customization
  * Resolves BB 37 TPNVIZ: create a Settings page
  * Resolves BB 48 TPNVIZ: Save settings (server side)
  * Closes #32 Config Option to change HTN node Font and Size
- Performance:
  * use keyword-identical? in favor of = for keyword comparisons
  * use simple keywords as key-fn's where applicable
- NOTE: This version requires [dollabs/webkeys "0.4.0"]

Signed-off-by: Tom Marble <tmarble@info9.net>