### PR TITLE
Added cider task back to build.boot

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -185,6 +185,7 @@
   "Cider boot params task"
   []
   (comp
-    ; What does this task do and it is really required? FIXME/TODO
-    ;(cider)
+    (cider) ;; defined in profile.boot
+    ;; FFI https://github.com/boot-clj/boot/wiki/Cider-REPL
+    ;;     https://cider.readthedocs.io/en/latest/installation/
     (cljs-dev)))


### PR DESCRIPTION
NOTE: requires cider to be defined in profile.boot per
  https://github.com/boot-clj/boot/wiki/Cider-REPL
  https://cider.readthedocs.io/en/latest/installation/

Signed-off-by: Tom Marble <tmarble@info9.net>