### PR TITLE
Fixes overlapping nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. This change
 ### [Unreleased]
 
 Changed
-* _TBD_
+* TPLAN: added rho check to medianpos to avoid overlapping nodes (fixes #53)
 
 ### [0.9.3] - 2017-02-01
 


### PR DESCRIPTION
TPLAN: added rho check to medianpos to avoid overlapping nodes
Fixes #53

Signed-off-by: Tom Marble <tmarble@info9.net>