### PR TITLE
Planviz creates `./config` unnecessarily (Fixes #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. This change
 
 Changed
 * TPLAN: added rho check to medianpos to avoid overlapping nodes (fixes #53)
+* Updated dependencies
+* Planviz creates `./config` unnecessarily (Fixes #49)
 
 ### [0.9.3] - 2017-02-01
 

--- a/build.boot
+++ b/build.boot
@@ -17,8 +17,8 @@
                     [org.clojure/clojurescript    "1.9.473"]
                     ;; both
                     [avenir                       "0.2.2"]
-                    [dollabs/webtasks             "0.2.2"]
-                    [dollabs/webkeys              "0.4.1"]
+                    [dollabs/webtasks             "0.2.3"]
+                    [dollabs/webkeys              "0.4.2"]
                     [org.clojure/core.async       "0.2.395"]
                     ;; server
                     [org.clojure/tools.cli        "0.3.5"]

--- a/src/planviz/server.clj
+++ b/src/planviz/server.clj
@@ -348,6 +348,7 @@
         out (with-out-str (pprint (dissoc settings
                                     :settings/filename
                                     :settings/filenames)))
+        _ (make-config-dir) ;; ensure /config exists
         _ (spit pathname out)
         filenames (list-settings-filenames)
         settings (assoc settings
@@ -1224,7 +1225,6 @@
   (let [filename "default"
         config-dir (str cwd "/config")
         path (str config-dir "/" filename settings-suffix)]
-    (make-config-dir)
     (if (fs/exists? path)
       (log/error "LOAD-DEFAULT-SETTINGS\n"
         (with-out-str (pprint (load-file path))))))
@@ -1249,7 +1249,6 @@
   (let [{:keys [cwd verbose log-level auto exchange rmq-host rmq-port
                 host port input url-config strict settings]} options
         _ (swap! state assoc-in [:cwd] cwd)
-        _ (make-config-dir) ;; ensure /config exists
         settings (load-settings-filename (or settings "default") auto)
         exchange (or exchange rmq-default-exchange)
         rmq-host (or rmq-host rmq-default-host)


### PR DESCRIPTION
Updated dependencies

Signed-off-by: Tom Marble <tmarble@info9.net>